### PR TITLE
Add a link to the notifications page in the navbar

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -18,7 +18,7 @@
             <%= link_to "Messages", "#", class: "nav-link" %>
           </li>
           <li class="nav-item">
-            <%= link_to "Notifications", "#", class: "nav-link" %>
+            <%= link_to "Notifications (Bell)", "#", class: "nav-link" %>
           </li>
           <li class="nav-item dropdown">
           <a href="#" class="avatar" id="navbarDropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -18,7 +18,7 @@
             <%= link_to "Messages", "#", class: "nav-link" %>
           </li>
           <li class="nav-item">
-            <%= link_to "Notifications (Bell)", "#", class: "nav-link" %>
+            <%= link_to "Notifications (Nice Bell)", "#", class: "nav-link" %>
           </li>
           <li class="nav-item dropdown">
           <a href="#" class="avatar" id="navbarDropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -17,6 +17,9 @@
           <li class="nav-item">
             <%= link_to "Messages", "#", class: "nav-link" %>
           </li>
+          <li class="nav-item">
+            <%= link_to "Notifications", "#", class: "nav-link" %>
+          </li>
           <li class="nav-item dropdown">
           <a href="#" class="avatar" id="navbarDropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar", alt: "dropdown menu" %>


### PR DESCRIPTION
# Navbar notification link

I add a link to all authenticated users of the application. The link will redirect them to the `/notifications` page where we'll display all notifications to the user. (cf. screenshot below)

<img width="506" alt="Screenshot 2024-10-07 at 11 00 07 am" src="https://github.com/user-attachments/assets/02904a1e-c1cb-4c69-955b-23d6716a67e5">

Work left:
- [ ] create the route for the `notifications#index`
- [ ] create `notifications` controller
- ...
